### PR TITLE
Fix Patch and Unpatch operations when JsonConvert.DefaultSettings is not null

### DIFF
--- a/Src/JsonDiffPatch.cs
+++ b/Src/JsonDiffPatch.cs
@@ -91,7 +91,7 @@ namespace JsonDiffPatchDotNet
 					&& left.Type == JTokenType.Array
 					&& arrayDiffCanary != null
 					&& arrayDiffCanary.Value.Type == JTokenType.String
-					&& arrayDiffCanary.ToObject<string>() == "a")
+					&& arrayDiffCanary.Value.ToObject<string>() == "a")
 				{
 					return ArrayPatch((JArray)left, patchObj);
 				}
@@ -176,7 +176,7 @@ namespace JsonDiffPatchDotNet
 					&& right.Type == JTokenType.Array
 					&& arrayDiffCanary != null
 					&& arrayDiffCanary.Value.Type == JTokenType.String
-					&& arrayDiffCanary.ToObject<string>() == "a")
+					&& arrayDiffCanary.Value.ToObject<string>() == "a")
 				{
 					return ArrayUnpatch((JArray)right, patchObj);
 				}


### PR DESCRIPTION
Hi @wbish,

Patch and Unpatch might fail if JsonConvert.DefaultSettings are overridden. This is caused by specifics of JToken.ToObject method that has explicit condition (JsonConvert.DefaultSettings == null). See:  
https://github.com/JamesNK/Newtonsoft.Json/issues/709

To illustrate this scenario the following can be added to unit test classes:
```
[OneTimeSetUp]
public void OneTimeSetUp(){
    JsonConvert.DefaultSettings = () => new JsonSerializerSettings();
}
```

Fix is that ToObject method is called on JProperty.Value instead of JProperty itself

Best regards,
Nikita (aka @arbitertl)