### PR TITLE
add project files for clean builds for .NET Standard

### DIFF
--- a/Src/JsonDiffPatchDotNet.NetStandard.sln
+++ b/Src/JsonDiffPatchDotNet.NetStandard.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonDiffPatchDotNet.NetStandard", "JsonDiffPatchDotNet\JsonDiffPatchDotNet.NetStandard.csproj", "{CB5ADECE-CCCE-402E-8682-7A90B6E26DC3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonDiffPatchDotNet.UnitTests.NetStandard", "JsonDiffPatchDotNet.UnitTests\JsonDiffPatchDotNet.UnitTests.NetStandard.csproj", "{9A89568A-263A-42F8-BBBF-815AC8D0BDD9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CB5ADECE-CCCE-402E-8682-7A90B6E26DC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB5ADECE-CCCE-402E-8682-7A90B6E26DC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB5ADECE-CCCE-402E-8682-7A90B6E26DC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB5ADECE-CCCE-402E-8682-7A90B6E26DC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A89568A-263A-42F8-BBBF-815AC8D0BDD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A89568A-263A-42F8-BBBF-815AC8D0BDD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A89568A-263A-42F8-BBBF-815AC8D0BDD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A89568A-263A-42F8-BBBF-815AC8D0BDD9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7CDD67CF-CD53-43DD-8CD5-9AD796C07C08}
+	EndGlobalSection
+EndGlobal

--- a/Src/JsonDiffPatchDotNet.UnitTests/JsonDiffPatchDotNet.UnitTests.NetStandard.csproj
+++ b/Src/JsonDiffPatchDotNet.UnitTests/JsonDiffPatchDotNet.UnitTests.NetStandard.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>JsonDiffPatchDotNet.UnitTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\JsonDiffPatchDotNet.UnitTests\DiffMatchPatchTest.cs" Link="DiffMatchPatchTest.cs" />
+    <Compile Include="..\JsonDiffPatchDotNet.UnitTests\DiffUnitTests.cs" Link="DiffUnitTests.cs" />
+    <Compile Include="..\JsonDiffPatchDotNet.UnitTests\PatchUnitTests.cs" Link="PatchUnitTests.cs" />
+    <Compile Include="..\JsonDiffPatchDotNet.UnitTests\UnpatchUnitTests.cs" Link="UnpatchUnitTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JsonDiffPatchDotNet\JsonDiffPatchDotNet.NetStandard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatchDotNet.NetStandard.csproj
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatchDotNet.NetStandard.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>JsonDiffPatchDotNet</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="packages.JsonDiffPatchDotNet.config" />
+    <None Remove="packages.JsonDiffPatchDotNet.Portable45.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
You would need to fix your CI, but these additional project files will build cleanly in .NET Core / .NET Standard. The current solution has portable binaries but pull in .NET 4.5 dependencies, breaking .NET Standard use in .NET Core.