### PR TITLE
Correct `Options.ArrayDiff` documentation

### DIFF
--- a/Src/JsonDiffPatchDotNet/Options.cs
+++ b/Src/JsonDiffPatchDotNet/Options.cs
@@ -10,7 +10,7 @@
 		}
 
 		/// <summary>
-		/// Specifies how arrays are diffed. The default is Simple.
+		/// Specifies how arrays are diffed. The default is Efficient.
 		/// </summary>
 		public ArrayDiffMode ArrayDiff { get; set; }
 


### PR DESCRIPTION
The doc comment for `Options.ArrayDiff` states that the default setting is `Simple`, but it is actually `Efficient` (line 7).