### PR TITLE
Fix non-compliant RFC 6902

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
@@ -92,6 +92,22 @@ namespace JsonDiffPatchDotNet.UnitTests
 			AssertOperation(operations[1], OperationTypes.Add, "/items/1", JValue.CreateString("bus"));
 		}
 
+		[Test]
+		public void Format_ArrayAddsInOrder_Success()
+		{
+			var jdp = new JsonDiffPatch();
+			var formatter = new JsonDeltaFormatter();
+			var left = JObject.Parse(@"{""items"":[]}");
+			var right = JObject.Parse(@"{""items"":[""bike"",""car"",""bus""]}");
+			var patch = jdp.Diff(left, right);
+			var operations = formatter.Format(patch);
+
+			Assert.AreEqual(3, operations.Count);
+			AssertOperation(operations[0], OperationTypes.Add, "/items/0", JValue.CreateString("bike"));
+			AssertOperation(operations[1], OperationTypes.Add, "/items/1", JValue.CreateString("car"));
+			AssertOperation(operations[2], OperationTypes.Add, "/items/2", JValue.CreateString("bus"));
+		}
+
 		private void AssertOperation(Operation operation, string expectedOp, string expectedPath, JValue expectedValue = null)
 		{
 			Assert.AreEqual(expectedOp, operation.Op);

--- a/Src/JsonDiffPatchDotNet/Formatters/BaseDeltaFormatter.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/BaseDeltaFormatter.cs
@@ -9,8 +9,6 @@ namespace JsonDiffPatchDotNet.Formatters
 	{
 		public delegate void DeltaKeyIterator(string key, string leftKey, MoveDestination movedFrom, bool isLast);
 
-		private static readonly IComparer<string> s_arrayKeyComparer = new ArrayKeyComparer();
-
 		public TResult Format(JToken delta)
 		{
 			var context = new TContext();
@@ -107,10 +105,7 @@ namespace JsonDiffPatchDotNet.Formatters
 				}
 			}
 
-			if (arrayKeys)
-				keys.Sort(s_arrayKeyComparer);
-			else
-				keys.Sort();
+			keys.Sort();
 
 			for (var index = 0; index < keys.Count; index++)
 			{


### PR DESCRIPTION
The RFC 6902 formatter produces a diff that is not compliant with the RFC. This occurs when there are multiple array additions.

An example:

Before:
```
{
   "array": []
}
```

After:
```
{
   "array": ["first","second"]
}
```

The RFC 6902 patch generated will be:

```
[
   {"op": "add", "path": "/array/1", "value": "second"},
   {"op": "add", "path": "/array/0", "value": "first"}
]
```

The RFC stipulates that the operations will be performed in the order they appear in the patch, and array additions cannot be beyond the last element + 1. This patch won't apply in this case because it tries to add at index 1 before index 0.

I'm not sure exactly why array operations are sorted in reverse order. The comment claims that it's because of the way `JsonDiffPatch.ArrayPatch` works, but this doesn't seem relevant to diff that is RFC 6902 formatted.