### PR TITLE
Fix non-compliant RFC 6902

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,5 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+.idea/

--- a/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
@@ -7,57 +7,63 @@ namespace JsonDiffPatchDotNet.UnitTests
 	[TestFixture]
 	public class JsonDeltaFormatterUnitTests
 	{
+		private static readonly JsonDiffPatch Differ = new JsonDiffPatch();
+		private static readonly JsonDeltaFormatter Formatter = new JsonDeltaFormatter();
+
+		[Test]
+		public void Format_EmptyDiffIsEmpty_Success()
+		{
+			var left = JObject.Parse(@"{}");
+			var right = JObject.Parse(@"{}");
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
+
+			Assert.AreEqual(0, operations.Count);
+		}
+
 		[Test]
 		public void Format_SupportsRemove_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
-			var left = JObject.Parse(@"{ ""p"" : true }");
-			var right = JObject.Parse(@"{ }");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var left = JObject.Parse(@"{ ""a"": ""a"", ""b"": ""b"", ""c"" : ""c"" }");
+			var right = JObject.Parse(@"{ ""a"": ""a"", ""b"": ""b"" }");
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(1, operations.Count);
-			AssertOperation(operations[0], OperationTypes.Remove, "/p");
+			AssertOperation(operations[0], OperationTypes.Remove, "/c");
 		}
 
 		[Test]
 		public void Format_SupportsAdd_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
-			var left = JObject.Parse(@"{ }");
-			var right = JObject.Parse(@"{ ""p"" : true }");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var left = JObject.Parse(@"{ ""a"": ""a"", ""b"": ""b"" }");
+			var right = JObject.Parse(@"{ ""a"": ""a"", ""b"": ""b"", ""c"" : ""c"" }");
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(1, operations.Count);
-			AssertOperation(operations[0], OperationTypes.Add, "/p", new JValue(true));
+			AssertOperation(operations[0], OperationTypes.Add, "/c", new JValue("c"));
 		}
 
 		[Test]
 		public void Format_SupportsReplace_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
-			var left = JObject.Parse(@"{ ""p"" : false }");
-			var right = JObject.Parse(@"{ ""p"" : true }");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var left = JObject.Parse(@"{ ""a"": ""a"", ""b"": ""b"" }");
+			var right = JObject.Parse(@"{ ""a"": ""a"", ""b"": ""c"" }");
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(1, operations.Count);
-			AssertOperation(operations[0], OperationTypes.Replace, "/p", new JValue(true));
+			AssertOperation(operations[0], OperationTypes.Replace, "/b", new JValue("c"));
 		}
 
 		[Test]
 		public void Format_SupportsArrayAdd_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
 			var left = JObject.Parse(@"{ ""items"" : [""car"", ""bus""] }");
 			var right = JObject.Parse(@"{ ""items"" : [""bike"", ""car"", ""bus""] }");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(1, operations.Count);
 			AssertOperation(operations[0], OperationTypes.Add, "/items/0", JValue.CreateString("bike"));
@@ -66,12 +72,10 @@ namespace JsonDiffPatchDotNet.UnitTests
 		[Test]
 		public void Format_SupportsArrayRemove_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
 			var left = JObject.Parse(@"{ ""items"" : [""bike"", ""car"", ""bus""] }");
 			var right = JObject.Parse(@"{ ""items"" : [""car"", ""bus""] }");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(1, operations.Count);
 			AssertOperation(operations[0], OperationTypes.Remove, "/items/0");
@@ -80,12 +84,10 @@ namespace JsonDiffPatchDotNet.UnitTests
 		[Test]
 		public void Format_SupportsArrayMove_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
 			var left = JObject.Parse(@"{ ""items"" : [""bike"", ""car"", ""bus""] }");
 			var right = JObject.Parse(@"{ ""items"" : [""bike"", ""bus"", ""car""] }");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(2, operations.Count);
 			AssertOperation(operations[0], OperationTypes.Remove, "/items/2");
@@ -93,19 +95,30 @@ namespace JsonDiffPatchDotNet.UnitTests
 		}
 
 		[Test]
-		public void Format_ArrayAddsInOrder_Success()
+		public void Format_ArrayAddsInAscOrder_Success()
 		{
-			var jdp = new JsonDiffPatch();
-			var formatter = new JsonDeltaFormatter();
-			var left = JObject.Parse(@"{""items"":[]}");
-			var right = JObject.Parse(@"{""items"":[""bike"",""car"",""bus""]}");
-			var patch = jdp.Diff(left, right);
-			var operations = formatter.Format(patch);
+			var left = JArray.Parse(@"[]");
+			var right = JArray.Parse(@"[1, 2, 3]");
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
 
 			Assert.AreEqual(3, operations.Count);
-			AssertOperation(operations[0], OperationTypes.Add, "/items/0", JValue.CreateString("bike"));
-			AssertOperation(operations[1], OperationTypes.Add, "/items/1", JValue.CreateString("car"));
-			AssertOperation(operations[2], OperationTypes.Add, "/items/2", JValue.CreateString("bus"));
+			AssertOperation(operations[0], OperationTypes.Add, "/0", new JValue(1));
+			AssertOperation(operations[1], OperationTypes.Add, "/1", new JValue(2));
+			AssertOperation(operations[2], OperationTypes.Add, "/2", new JValue(3));
+		}
+
+		[Test]
+		public void Format_ArrayRemoveInDescOrder_Success()
+		{
+			var left = JArray.Parse("[1, 2, 3]");
+			var right = JArray.Parse("[1]");
+			var patch = Differ.Diff(left, right);
+			var operations = Formatter.Format(patch);
+
+			Assert.AreEqual(2, operations.Count);
+			AssertOperation(operations[0], OperationTypes.Remove, "/2");
+			AssertOperation(operations[1], OperationTypes.Remove, "/1");
 		}
 
 		private void AssertOperation(Operation operation, string expectedOp, string expectedPath, JValue expectedValue = null)

--- a/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
@@ -92,6 +92,22 @@ namespace JsonDiffPatchDotNet.UnitTests
 			AssertOperation(operations[1], OperationTypes.Add, "/items/1", JValue.CreateString("bus"));
 		}
 
+		[Test]
+		public void Format_ArrayAddsInOrder_Success()
+		{
+			var jdp = new JsonDiffPatch();
+			var formatter = new JsonDeltaFormatter();
+			var left = JObject.Parse(@"{""items"":[]}");
+			var right = JObject.Parse(@"{""items"":[""bike"",""car"",""bus""]}");
+			var patch = jdp.Diff(left, right);
+			var operations = formatter.Format(patch);
+
+			Assert.AreEqual(3, operations.Count);
+			AssertOperation(operations[0], OperationTypes.Add, "/items/0", JValue.CreateString("bike"));
+			AssertOperation(operations[1], OperationTypes.Add, "/items/1", JValue.CreateString("car"));
+			AssertOperation(operations[2], OperationTypes.Add, "/items/2", JValue.CreateString("bus"));
+		}
+
 		private void AssertOperation(Operation operation, string expectedOp, string expectedPath, JValue expectedValue = null)
 		{
 			Assert.AreEqual(expectedOp, operation.Op);

--- a/Src/JsonDiffPatchDotNet/Formatters/ArrayKeyComparer.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/ArrayKeyComparer.cs
@@ -6,10 +6,7 @@ namespace JsonDiffPatchDotNet.Formatters
 	{
 		public int Compare(string x, string y)
 		{
-			// This purposefully REVERSED from benjamine/jsondiffpatch,
-			// In order to match logic found in JsonDiffPatch.ArrayPatch,
-			// which applies operations in reverse order to avoid shifting floor
-			return ArrayKeyToSortNumber(y) - ArrayKeyToSortNumber(x);
+			return ArrayKeyToSortNumber(x) - ArrayKeyToSortNumber(y);
 		}
 
 		private static int ArrayKeyToSortNumber(string key)

--- a/Src/JsonDiffPatchDotNet/Formatters/BaseDeltaFormatter.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/BaseDeltaFormatter.cs
@@ -11,7 +11,7 @@ namespace JsonDiffPatchDotNet.Formatters
 
 		private static readonly IComparer<string> s_arrayKeyComparer = new ArrayKeyComparer();
 
-		public TResult Format(JToken delta)
+		public virtual TResult Format(JToken delta)
 		{
 			var context = new TContext();
 			Recurse(context, delta, left: null, key: null, leftKey: null, movedFrom: null, isLast: false);


### PR DESCRIPTION
The RFC 6902 formatter produces a diff that is not compliant with the RFC. This occurs when there are multiple array additions.

An example:

Before:
```
{
   "array": []
}
```

After:
```
{
   "array": ["first","second"]
}
```

The RFC 6902 patch generated will be:
```
[
   {"op": "add", "path": "/array/1", "value": "second"},
   {"op": "add", "path": "/array/0", "value": "first"}
]
```

The RFC stipulates that the operations will be performed in the order they appear in the patch, and array additions cannot be beyond the last element + 1. This patch won't apply in this case because it tries to add at index 1 before index 0.

This PR removes the incorrect implementation which reversed all array operations, and ports the code from https://github.com/benjamine/jsondiffpatch that handles this correctly.