### PR TITLE
Fix obscure bug with array sorting

### DIFF
--- a/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonDeltaFormatter.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonDeltaFormatter.cs
@@ -94,8 +94,8 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 			var removeOpsOtherOps = PartitionRemoveOps(result);
 			var removeOps = removeOpsOtherOps[0];
 			var otherOps = removeOpsOtherOps[1];
-			Array.Sort(removeOps, new RemoveOperationComparer());
-			return removeOps.Concat(otherOps).ToList();
+			var removeOpsReverse = removeOps.OrderBy(x => x.Path, new PathComparer());
+			return removeOpsReverse.Concat(otherOps).ToList();
 		}
 
 		private IList<Operation[]> PartitionRemoveOps(IList<Operation> result)
@@ -109,15 +109,15 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 			return new List<Operation[]> {left.ToArray(), right.ToArray()};
 		}
 
-		private class RemoveOperationComparer : IComparer<Operation>
+		private class PathComparer : IComparer<string>
 		{
-			public int Compare(Operation a, Operation b)
+			public int Compare(string a, string b)
 			{
 				if (a == null) throw new ArgumentNullException(nameof(a));
 				if (b == null) throw new ArgumentNullException(nameof(b));
 
-				var splitA = a.Path.Split('/');
-				var splitB = b.Path.Split('/');
+				var splitA = a.Split('/');
+				var splitB = b.Split('/');
 
 				return splitA.Length != splitB.Length
 					? splitA.Length - splitB.Length


### PR DESCRIPTION
Using `Array.Sort` can produce incorrect results with this comparer, depending on the input, due to different sorting algorithms potentially being used.

The issue is that the comparer considers an array index path and a non-index paths to be equal. This means two unequal index paths can be considered equal because they are both equal to the same non-index path.

E.g. `/a/b/c/0 == /a/b/c/d` and `/a/b/c/1 == /a/b/c/d` therefore `/a/b/c/0 == /a/b/c/1`

Switch to using `Enumerable.OrderBy`, which provides a stable sort, alleviating this issue. It is also consistent with the source implementation of this port.