### PR TITLE
Property Filter and Patch Behavior Solution (Resolves #34)

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json.Linq;
@@ -296,6 +297,6 @@ namespace JsonDiffPatchDotNet.UnitTests
 			Assert.AreEqual(2, array.Count);
 			Assert.AreEqual(left, array[0]);
 			Assert.AreEqual(right, array[1]);
-		}
+		}		
 	}
 }

--- a/Src/JsonDiffPatchDotNet/DiffBehavior.cs
+++ b/Src/JsonDiffPatchDotNet/DiffBehavior.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonDiffPatchDotNet
+{
+	[Flags]
+	public enum DiffBehavior
+	{
+		/// <summary>
+		/// Default behavior
+		/// </summary>
+		None,
+		/// <summary>
+		/// If the patch document is missing properties that are in the source document, leave the existing properties in place instead of deleting them
+		/// </summary>
+		IgnoreMissingProperties,
+		/// <summary>
+		/// If the patch document contains properties that aren't defined in the source document, ignore them instead of adding them
+		/// </summary>
+		IgnoreNewProperties
+	}
+}

--- a/Src/JsonDiffPatchDotNet/Options.cs
+++ b/Src/JsonDiffPatchDotNet/Options.cs
@@ -1,7 +1,11 @@
-﻿namespace JsonDiffPatchDotNet
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace JsonDiffPatchDotNet
 {
 	public sealed class Options
-	{
+	{		
 		public Options()
 		{
 			ArrayDiff = ArrayDiffMode.Efficient;
@@ -24,5 +28,15 @@
 		/// length is not met, simple text diff will be used. The default length is 50 characters.
 		/// </summary>
 		public long MinEfficientTextDiffLength { get; set; }
+
+		/// <summary>
+		/// Specifies which paths to exclude from the diff patch set
+		/// </summary>
+		public List<string> ExcludePaths { get; set; } = new List<string>();
+
+		/// <summary>
+		/// Specifies behaviors to apply to the diff patch set
+		/// </summary>
+		public DiffBehavior DiffBehaviors { get; set; }
 	}
 }


### PR DESCRIPTION
Resolves #34. This change extends the capabilities of the Option class that is leveraged by JsonDiffPatch to apply diff patches. This change introduces an ExcludePaths property that allows you to specify the paths of the properties that you want the patch process to ignore. This is useful for preventing Id or other sensitive fields from being updated. This change also introduces a DiffBehaviors property that allows you to modify the behavior of the diff patch process. Specifying a behavior of "IgnoreMissingProperties" will prevent the patch process from deleting properties from the source object that aren't specified in the patch object, creating an avenue for partial updates to be applied. Specifying a behavior of "IgnoreNewProperties" will pevent properties that exist in the patch object but not in the source object from being applied to the source object. The implementation is applied exactly in accordance to the comment I made on issue #34 - https://github.com/wbish/jsondiffpatch.net/issues/34"s that is leveraged by JsonDiffPatch to apply diff patches. This change introduces an ExcludePaths property that allows you to specify the paths of the properties that you want the patch process to ignore. This is useful for preventing Id or other sensitive fields from being updated. This change also introduces a DiffBehaviors property that allows you to modify the behavior of the diff patch process. Specifying a behavior of IgnoreMissingProperties will prevent the patch process from deleting properties from the source object that aren't specified in the patch object, creating an avenue for partial updates to be applied. Specifying a behavior of IgnoreNewProperties will pevent properties that exist in the patch object but not in the source object from being applied to the source object. The implementation is applied exactly in accordance to the comment I made on issue #34 - https://github.com/wbish/jsondiffpatch.net/issues/34