### PR TITLE
Implementation of Object Hash 

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
@@ -225,9 +225,9 @@ namespace JsonDiffPatchDotNet.UnitTests
 		[Test]
 		public void Diff_EfficientArrayDiffSameLengthNested_ValidDiff()
 		{
-			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient });
-			var left = JToken.Parse(@"[1,2,{""p"":false},4]");
-			var right = JToken.Parse(@"[1,2,{""p"":true},4]");
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, ObjectHash = (jObj) => jObj["Id"].Value<string>() });
+			var left = JToken.Parse(@"[1,2,{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false},4]");
+			var right = JToken.Parse(@"[1,2,{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":true},4]");
 
 			JObject diff = jdp.Diff(left, right) as JObject;
 
@@ -236,7 +236,21 @@ namespace JsonDiffPatchDotNet.UnitTests
 			Assert.IsNotNull(diff["2"]);
 		}
 
-		[Test]
+        [Test]
+        public void Diff_EfficientArrayDiffWithComplexObject_ValidDiff()
+        {
+            var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, ObjectHash = (jObj) => jObj["Id"].Value<string>() });
+            //var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient });
+            var left = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}]");
+            var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":false}]");
+
+            JObject diff = jdp.Diff(left, right) as JObject;
+
+            Assert.IsNotNull(diff);
+            Assert.AreEqual(4, diff.Properties().Count());
+        }
+
+        [Test]
 		public void Diff_EfficientArrayDiffSameWithObject_NoDiff()
 		{
 			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient });

--- a/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
@@ -250,7 +250,23 @@ namespace JsonDiffPatchDotNet.UnitTests
             Assert.AreEqual(4, diff.Properties().Count());
         }
 
-        [Test]
+		[Test]
+		public void Diff_EfficientArrayDiffWithComplexObjectHash_ValidDiff()
+		{
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, ObjectHash = (jObj) => jObj["Id"].Value<string>() });
+			var left = JToken.Parse(@"[{""Id"": ""22ff56c7-2307-414b-8a3a-9bf1cdba2095"",""city"":""São Paulo""},{""Id"":""3fca9cdb-dd9b-4b7c-afc1-587751e25bd6"",""city"":""abc""},{""Id"":""1fe6a0f9-3974-427f-81cb-6004748cb179"",""city"":""xyz""}]");
+			var right = JToken.Parse(@"[{""Id"":""3fca9cdb-dd9b-4b7c-afc1-587751e25bd6"",""city"":""abc""},{""Id"":""1fe6a0f9-3974-427f-81cb-6004748cb179"",""city"":""xyz""}, {""Id"":""3fca9cdb-dd9b-4b7c-afc1-587751e25b44"",""city"":""new""}]");
+
+			JObject diff = jdp.Diff(left, right) as JObject;
+
+			Assert.IsNotNull(diff);
+			Assert.AreEqual(3, diff.Properties().Count());
+			Assert.IsNotNull(diff["_0"]);
+			Assert.IsNotNull(diff["2"]);
+			Assert.AreEqual(((JArray)diff["2"])[0].Value<string>("city"), "new");
+		}
+
+		[Test]
 		public void Diff_EfficientArrayDiffSameWithObject_NoDiff()
 		{
 			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient });

--- a/Src/JsonDiffPatchDotNet/ArrayDiffMode.cs
+++ b/Src/JsonDiffPatchDotNet/ArrayDiffMode.cs
@@ -16,6 +16,6 @@
 		/// the entire left and entire right arrays are added to the patch document as a simple
 		/// JSON token replace. If they are the same, then token is skipped in the patch document.
 		/// </summary>
-		Simple,
+		Simple
 	}
 }

--- a/Src/JsonDiffPatchDotNet/DefaultItemMatch.cs
+++ b/Src/JsonDiffPatchDotNet/DefaultItemMatch.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonDiffPatchDotNet
+{
+    public class DefaultItemMatch : ItemMatch
+    {
+        public DefaultItemMatch(Func<JToken, object> objectHash):base(objectHash)
+        {
+            
+        }
+    }
+}

--- a/Src/JsonDiffPatchDotNet/ItemMatch.cs
+++ b/Src/JsonDiffPatchDotNet/ItemMatch.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonDiffPatchDotNet
+{
+    public abstract class ItemMatch
+    {
+        internal Func<JToken, object> ObjectHash;
+
+        protected ItemMatch()
+        {
+            
+        }
+
+        protected ItemMatch(Func<JToken, object> objectHash)
+        {
+            ObjectHash = objectHash;
+        }
+
+        public virtual bool Match(JToken object1, JToken object2)
+        {
+            return Match(object1, object2, ObjectHash);
+        }
+
+        public virtual bool Match(JToken object1, JToken object2, Func<JToken, object> objectHash)
+        {
+            if(objectHash == null || object1.Type != JTokenType.Object)
+            {
+                return JToken.DeepEquals(object1, object2);
+            }
+
+            var hash1 = objectHash.Invoke(object1);
+            if(hash1 == null)
+            {
+                return false;
+            }
+            var hash2 = objectHash.Invoke(object2);
+            if(hash2 == null)
+            {
+                return false;
+            }
+            return hash1.Equals(hash2);
+        }
+    }
+}

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
@@ -384,8 +384,8 @@ namespace JsonDiffPatchDotNet
             int commonHead = 0;
             int commonTail = 0;
 
-            if (itemMatch.Match(left, right))
-                return null;
+			if (JToken.DeepEquals(left, right))
+				return null;
 
             var childContext = new List<JToken>();
 

--- a/Src/JsonDiffPatchDotNet/Lcs.cs
+++ b/Src/JsonDiffPatchDotNet/Lcs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -50,29 +50,34 @@ namespace JsonDiffPatchDotNet
 
         private static Lcs Backtrack(int[,] matrix, List<JToken> left, List<JToken> right, int li, int ri, ItemMatch match)
         {
+            var index1 = li;
+            var index2 = ri;
             var result = new Lcs();
-            for (int i = 1, j = 1; i <= li && j <= ri;)
-            {
-                // If the JSON tokens at the same position are both Objects or both Arrays, we just say they 
-                // are the same even if they are not, because we can package smaller deltas than an entire 
-                // object or array replacement by doing object to object or array to array diff.
-                if (match.Match(left[i - 1], right[j - 1]))
-                {
-                    result.Sequence.Add(left[i - 1]);
-                    result.Indices1.Add(i - 1);
-                    result.Indices2.Add(j - 1);
-                    i++;
-                    j++;
-                    continue;
-                }
 
-                if (matrix[i, j - 1] > matrix[i - 1, j])
+            while (index1 != 0 && index2 != 0)
+            {
+                var sameLetter = match.Match(left[index1 - 1], right[index2 - 1]);
+
+                if (sameLetter)
                 {
-                    i++;
+                    result.Sequence.Add(left[index1 - 1]);
+                    result.Indices1.Add(index1 - 1);
+                    result.Indices2.Add(index2 - 1);
+                    --index1;
+                    --index2;
                 }
                 else
                 {
-                    j++;
+                    var valueAtMatrixAbove = matrix[index1, index2 - 1];
+                    var valueAtMatrixLeft = matrix[index1 - 1, index2];
+                    if (valueAtMatrixAbove > valueAtMatrixLeft)
+                    {
+                        --index2;
+                    }
+                    else
+                    {
+                        --index1;
+                    }
                 }
             }
 

--- a/Src/JsonDiffPatchDotNet/Lcs.cs
+++ b/Src/JsonDiffPatchDotNet/Lcs.cs
@@ -4,51 +4,51 @@ using Newtonsoft.Json.Linq;
 
 namespace JsonDiffPatchDotNet
 {
-	internal class Lcs
-	{
-		internal List<JToken> Sequence { get; set; }
+    internal class Lcs
+    {
+        internal List<JToken> Sequence { get; set; }
 
-		internal List<int> Indices1 { get; set; }
+        internal List<int> Indices1 { get; set; }
 
-		internal List<int> Indices2 { get; set; }
+        internal List<int> Indices2 { get; set; }
 
-		private Lcs()
-		{
-			Sequence = new List<JToken>();
-			Indices1 = new List<int>();
-			Indices2 = new List<int>();
-		}
+        private Lcs()
+        {
+            Sequence = new List<JToken>();
+            Indices1 = new List<int>();
+            Indices2 = new List<int>();
+        }
 
-		internal static Lcs Get(List<JToken> left, List<JToken> right)
-		{
-			var matrix = LcsInternal(left, right);
-			var result = Backtrack(matrix, left, right, left.Count, right.Count);
-			return result;
-		}
+        internal static Lcs Get(List<JToken> left, List<JToken> right, ItemMatch match)
+        {
+            var matrix = LcsInternal(left, right, match);
+            var result = Backtrack(matrix, left, right, left.Count, right.Count, match);
+            return result;
+        }
 
-		private static int[,] LcsInternal(List<JToken> left, List<JToken> right)
-		{
-			var arr = new int[left.Count + 1, right.Count + 1];
+        private static int[,] LcsInternal(List<JToken> left, List<JToken> right, ItemMatch match)
+        {
+            var arr = new int[left.Count + 1, right.Count + 1];
 
-			for (int i = 1; i <= left.Count; i++)
-			{
-				for (int j = 1; j <= right.Count; j++)
-				{
-					if (JToken.DeepEquals(left[i - 1], right[j - 1]))
-					{
-						arr[i, j] = arr[i - 1, j - 1] + 1;
-					}
-					else
-					{
-						arr[i, j] = Math.Max(arr[i - 1, j], arr[i, j - 1]);
-					}
-				}
-			}
+            for (int i = 1; i <= left.Count; i++)
+            {
+                for (int j = 1; j <= right.Count; j++)
+                {
+                    if (match.Match(left[i - 1], right[j - 1]))
+                    {
+                        arr[i, j] = arr[i - 1, j - 1] + 1;
+                    }
+                    else
+                    {
+                        arr[i, j] = Math.Max(arr[i - 1, j], arr[i, j - 1]);
+                    }
+                }
+            }
 
-			return arr;
-		}
+            return arr;
+        }
 
-        private static Lcs Backtrack(int[,] matrix, List<JToken> left, List<JToken> right, int li, int ri)
+        private static Lcs Backtrack(int[,] matrix, List<JToken> left, List<JToken> right, int li, int ri, ItemMatch match)
         {
             var result = new Lcs();
             for (int i = 1, j = 1; i <= li && j <= ri;)
@@ -56,9 +56,7 @@ namespace JsonDiffPatchDotNet
                 // If the JSON tokens at the same position are both Objects or both Arrays, we just say they 
                 // are the same even if they are not, because we can package smaller deltas than an entire 
                 // object or array replacement by doing object to object or array to array diff.
-                if (JToken.DeepEquals(left[i - 1], right[j - 1])
-                || left[i - 1].Type == JTokenType.Object && right[j - 1].Type == JTokenType.Object
-                || left[i - 1].Type == JTokenType.Array && right[j - 1].Type == JTokenType.Array)
+                if (match.Match(left[i - 1], right[j - 1]))
                 {
                     result.Sequence.Add(left[i - 1]);
                     result.Indices1.Add(i - 1);

--- a/Src/JsonDiffPatchDotNet/Options.cs
+++ b/Src/JsonDiffPatchDotNet/Options.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -18,16 +19,16 @@ namespace JsonDiffPatchDotNet
 		/// </summary>
 		public ArrayDiffMode ArrayDiff { get; set; }
 
-		/// <summary>
-		/// Specifies how string values are diffed. The default is Efficient.
-		/// </summary>
-		public TextDiffMode TextDiff { get; set; }
+        /// <summary>
+        /// Specifies how string values are diffed. The default is Efficient.
+        /// </summary>
+        public TextDiffMode TextDiff { get; set; }
 
-		/// <summary>
-		/// The minimum string length required to use Efficient text diff. If the minimum
-		/// length is not met, simple text diff will be used. The default length is 50 characters.
-		/// </summary>
-		public long MinEfficientTextDiffLength { get; set; }
+        /// <summary>
+        /// The minimum string length required to use Efficient text diff. If the minimum
+        /// length is not met, simple text diff will be used. The default length is 50 characters.
+        /// </summary>
+        public long MinEfficientTextDiffLength { get; set; }
 
 		/// <summary>
 		/// Specifies which paths to exclude from the diff patch set
@@ -38,5 +39,17 @@ namespace JsonDiffPatchDotNet
 		/// Specifies behaviors to apply to the diff patch set
 		/// </summary>
 		public DiffBehavior DiffBehaviors { get; set; }
-	}
+		
+        /// <summary>
+        /// for LCS to work, it needs a way to match items between previous/original (or left/right) arrays. In traditional text diff tools this is trivial, as two lines of text are compared char 
+        /// char.
+        /// When no matches by reference or value are found, array diffing fallbacks to a dumb behavior: matching items by position.
+        /// Matching by position is not the most efficient option (eg. if an item is added at the first position, all the items below will be considered modified), but it produces expected results
+        /// in most trivial cases.This is good enough as soon as movements/insertions/deletions only happen near the bottom of the array.
+        /// This is because if 2 objects are not equal by reference(ie.the same object) both objects are considered different values, as there is no trivial solution to compare two arbitrary objects
+        /// in JavaScript.
+        /// To improve the results leveraging the power of LCS(and position move detection) you need to provide a way to compare 2 objects.
+        /// </summary>
+        public Func<JToken, object> ObjectHash { get; set; }
+    }
 }


### PR DESCRIPTION
Compare array elements with an identifier instead of array position.
This function work same as [benjamine/jsondiffpatch object-hash](https://github.com/benjamine/jsondiffpatch/blob/master/docs/arrays.md#an-object-hash)

The backtrack function of LCS know search the matrix from bottom right to top left. 
Like described in [Wikipedia](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem)

This pull request is based on #52
fixes issue #54, #42 