### PR TITLE
fix: escape the key with ~ or/in its the json Pointer name

### DIFF
--- a/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonDeltaFormatter.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonDeltaFormatter.cs
@@ -51,7 +51,7 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 
 		protected override void NodeBegin(JsonFormatContext context, string key, string leftKey, DeltaType type, NodeType nodeType, bool isLast)
 		{
-			context.Path.Add(leftKey);
+			context.Path.Add(Escape(leftKey));
 		}
 
 		protected override void NodeEnd(JsonFormatContext context, string key, string leftKey, DeltaType type, NodeType nodeType, bool isLast)
@@ -63,6 +63,13 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 		protected override void RootBegin(JsonFormatContext context, DeltaType type, NodeType nodeType) { }
 
 		protected override void RootEnd(JsonFormatContext context, DeltaType type, NodeType nodeType) { }
+
+		private string Escape(string key)
+		{
+			if (string.IsNullOrEmpty(key)) return key;
+			return key.Replace("~", "~0")
+				.Replace("/", "~1");
+		}
 
 		private void FormatNode(JsonFormatContext context, JToken delta, JToken left)
 		{


### PR DESCRIPTION
As mentioned in the [IETF RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901) specification documentation， the key with ~ or/in its the JSON Pointer name needs to be escaped
For example, to get "ab" from { "a/b": "ab" } you’d use the pointer "/a~1b"