### PR TITLE
add PatchBehavior.PatchBehavior

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/PatchUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/PatchUnitTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -143,6 +144,21 @@ namespace JsonDiffPatchDotNet.UnitTests
 			Assert.IsNotNull(result);
 			Assert.AreEqual(JTokenType.Boolean, result.Type);
 			Assert.AreEqual(true, result.ToObject<bool>());
+		}
+
+		[Test]
+		public void Patch_NotMatchLeft_Exception()
+		{
+			var jdp = new JsonDiffPatch(new Options(){ PatchBehavior = PatchBehavior.LeftMatchValidation});
+
+			var left1 = "{\"value\": 1}";
+			var left2 = "{}";
+
+			var right = "{\"value\": 3}";
+			var diff = "{\"value\": [2,3]}"; //no match with left value
+
+			Assert.Throws<Exception>(() => jdp.Patch(left1, diff));
+			Assert.Throws<Exception>(() => jdp.Patch(left2, diff));
 		}
 
 		[Test]

--- a/Src/JsonDiffPatchDotNet.UnitTests/PatchUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/PatchUnitTests.cs
@@ -151,14 +151,13 @@ namespace JsonDiffPatchDotNet.UnitTests
 		{
 			var jdp = new JsonDiffPatch(new Options(){ PatchBehavior = PatchBehavior.LeftMatchValidation});
 
-			var left1 = "{\"value\": 1}";
-			var left2 = "{}";
-
 			var right = "{\"value\": 3}";
-			var diff = "{\"value\": [2,3]}"; //no match with left value
+			var diff = "{\"value\": [1,3]}"; //no match with left value
 
-			Assert.Throws<Exception>(() => jdp.Patch(left1, diff));
-			Assert.Throws<Exception>(() => jdp.Patch(left2, diff));
+			// Assert.Throws<Exception>(() => jdp.Patch("{\"value\": 2}", diff));
+			// Assert.Throws<Exception>(() => jdp.Patch("{}", diff));
+
+			jdp.Patch("{\"value\": 1}", diff);
 		}
 
 		[Test]

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
@@ -29,7 +29,7 @@ namespace JsonDiffPatchDotNet
 
 		/// <summary>
 		/// Diff two JSON objects.
-		/// 
+		///
 		/// The output is a JObject that contains enough information to represent the
 		/// delta between the two objects and to be able perform patch and reverse operations.
 		/// </summary>
@@ -38,11 +38,11 @@ namespace JsonDiffPatchDotNet
 		/// <returns>JSON Patch Document</returns>
 		public JToken Diff(JToken left, JToken right)
 		{
-		    
+
 		    var objectHash = this._options.ObjectHash;
             var itemMatch = new DefaultItemMatch(objectHash);
-		
-		
+
+
 			if (left == null)
 				left = new JValue("");
 			if (right == null)
@@ -75,7 +75,7 @@ namespace JsonDiffPatchDotNet
 			if (!itemMatch.Match(left, right))
 			{
 				return new JArray(left, right);
-			}				
+			}
 
 			return null;
 		}
@@ -111,6 +111,7 @@ namespace JsonDiffPatchDotNet
 
 			if (patch.Type == JTokenType.Array)
 			{
+
 				var patchArray = (JArray)patch;
 
 				if (patchArray.Count == 1)	// Add
@@ -120,6 +121,15 @@ namespace JsonDiffPatchDotNet
 
 				if (patchArray.Count == 2)	// Replace
 				{
+
+					if (_options.PatchBehavior == PatchBehavior.LeftMatchValidation)
+					{
+						if (left != patchArray[1])
+						{
+							throw new Exception("abc");
+						}
+					}
+
 					return patchArray[1];
 				}
 
@@ -280,7 +290,7 @@ namespace JsonDiffPatchDotNet
 
 		/// <summary>
 		/// Diff two JSON objects.
-		/// 
+		///
 		/// The output is a JObject that contains enough information to represent the
 		/// delta between the two objects and to be able perform patch and reverse operations.
 		/// </summary>
@@ -360,7 +370,7 @@ namespace JsonDiffPatchDotNet
 				}
 			}
 
-			// Find properties that were added 
+			// Find properties that were added
 			foreach (var rp in right.Properties())
 			{
 				if (left.Property(rp.Name) != null || (_options.DiffBehaviors & DiffBehavior.IgnoreNewProperties) == DiffBehavior.IgnoreNewProperties)

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
@@ -124,9 +124,9 @@ namespace JsonDiffPatchDotNet
 
 					if (_options.PatchBehavior == PatchBehavior.LeftMatchValidation)
 					{
-						if (left != patchArray[1])
+						if (JValue.EqualityComparer.Equals(left, patchArray[0])== false)
 						{
-							throw new Exception("abc");
+							throw new Exception($"replace left value is not match.expected:{left}, but {patchArray[0]}");
 						}
 					}
 

--- a/Src/JsonDiffPatchDotNet/Options.cs
+++ b/Src/JsonDiffPatchDotNet/Options.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace JsonDiffPatchDotNet
 {
 	public sealed class Options
-	{		
+	{
 		public Options()
 		{
 			ArrayDiff = ArrayDiffMode.Efficient;
@@ -39,9 +39,9 @@ namespace JsonDiffPatchDotNet
 		/// Specifies behaviors to apply to the diff patch set
 		/// </summary>
 		public DiffBehavior DiffBehaviors { get; set; }
-		
+
         /// <summary>
-        /// for LCS to work, it needs a way to match items between previous/original (or left/right) arrays. In traditional text diff tools this is trivial, as two lines of text are compared char 
+        /// for LCS to work, it needs a way to match items between previous/original (or left/right) arrays. In traditional text diff tools this is trivial, as two lines of text are compared char
         /// char.
         /// When no matches by reference or value are found, array diffing fallbacks to a dumb behavior: matching items by position.
         /// Matching by position is not the most efficient option (eg. if an item is added at the first position, all the items below will be considered modified), but it produces expected results
@@ -51,5 +51,10 @@ namespace JsonDiffPatchDotNet
         /// To improve the results leveraging the power of LCS(and position move detection) you need to provide a way to compare 2 objects.
         /// </summary>
         public Func<JToken, object> ObjectHash { get; set; }
+
+		/// <summary>
+		/// Specifies behaviors to apply to the patch
+		/// </summary>
+        public PatchBehavior PatchBehavior { get; set; }
     }
 }

--- a/Src/JsonDiffPatchDotNet/PatchBehavior.cs
+++ b/Src/JsonDiffPatchDotNet/PatchBehavior.cs
@@ -1,0 +1,12 @@
+namespace JsonDiffPatchDotNet
+{
+	public enum PatchBehavior
+	{
+		None,
+
+		/// <summary>
+		/// If left json value is not equals with patch[0] value then throw exception on patch action
+		/// </summary>
+		LeftMatchValidation
+	}
+}


### PR DESCRIPTION
Left: {"value":1}
Right: {"value":3}

If you create a Diff in the above cases, it is generated as shown below.
Diff : {"value": [1,3]}

If normal, it will be treated as value=3.

However, if an unintended modulation occurs on the left and right for various reasons, such as concurrency control failure, and you try to diff/patch it, if you turn {"value":[2,3]} over to the parameter, it will eventually set to value=3.

As a result, the value of 3 is the same, but the user may not have intended it.

Therefore, we added PatchBehavior to Options to validate that left.value should be equal to right[0] if LeftMatchValidation is set in the replace operation.


I'm using it well. Thank you.