### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/JsonDeltaFormatterUnitTests.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using JsonDiffPatchDotNet.Formatters.JsonPatch;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using System.Linq;
 
 namespace JsonDiffPatchDotNet.UnitTests
 {

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatchDotNet.csproj
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatchDotNet.csproj
@@ -14,7 +14,7 @@
     <Authors>William Bishop</Authors>
     <Title>JsonDiffPatch.Net</Title>
     <Copyright>Copyright © William Bishop 2017</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/wbish/jsondiffpatch.net/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>JSON object diffs and reversible patching</Description>
     <PackageId>JsonDiffPatch.Net</PackageId>
     <PackageTags>json diff patch unpatch</PackageTags>


### PR DESCRIPTION
License expression is the preferred way (shows in NuGet.org and used in license validations). Also fixed a build warning caused by a duplicate using statement.