### PR TITLE
Add optional old value in replace operation

### DIFF
--- a/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonDeltaFormatter.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonDeltaFormatter.cs
@@ -83,7 +83,7 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 
 		private void FormatModified(JsonFormatContext context, JToken delta)
 		{
-			context.PushCurrentOp(OperationTypes.Replace, delta[1]);
+			context.PushCurrentOp(OperationTypes.Replace, delta[1], delta[0]);
 		}
 
 		private void FormatDeleted(JsonFormatContext context)

--- a/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonFormatContext.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/JsonFormatContext.cs
@@ -25,9 +25,9 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 			Operations.Add(new Operation(op, CurrentPath(), null));
 		}
 
-		public void PushCurrentOp(string op, object value)
+		public void PushCurrentOp(string op, object value, object oldValue = null)
 		{
-			Operations.Add(new Operation(op, CurrentPath(), null, value));
+			Operations.Add(new Operation(op, CurrentPath(), null, value, oldValue));
 		}
 
 		public void PushMoveOp(string to)

--- a/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/Operation.cs
+++ b/Src/JsonDiffPatchDotNet/Formatters/JsonPatch/Operation.cs
@@ -13,12 +13,13 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 			From = from;
 		}
 
-		public Operation(string op, string path, string from, object value)
+		public Operation(string op, string path, string from, object value, object oldValue)
 		{
 			Op = op;
 			Path = path;
 			From = from;
 			Value = value;
+			OldValue = oldValue;
 		}
 
 		[JsonProperty("path")]
@@ -32,5 +33,8 @@ namespace JsonDiffPatchDotNet.Formatters.JsonPatch
 
 		[JsonProperty("value")]
 		public object Value { get; set; }
+		
+		[JsonProperty("old", NullValueHandling = NullValueHandling.Ignore)]
+		public object OldValue { get; set; }
 	}
 }


### PR DESCRIPTION
When `OperationTypes.Replace` it will capture the replace value and add it to the operation. The _old_ property is only _JSON_ visible when not null. Hence, the following output can be achieved:

The diff:
```json
{"building":{"loc":{"provision":["2023-12-18T15:08:26Z","2024-02-01T16:00:00Z"]}}}
```

The json delta formatter:
```json
[{"path":"/building/loc/provision","op":"replace","value":"2024-02-01T16:00:00Z","old":"2023-12-18T15:08:26Z"}]
```

I'm on a Mac and do not have mono, so sorry for not providing any unit test - I've used it in my other project code and it seems to work properly.

I hope, this is a valid contribution. Please tell me otherwise and I'll fix it.

Cheers,
 Mario :)