### PR TITLE
Default to index matching and not full object comparison in array diffs.

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/DiffUnitTests.cs
@@ -220,20 +220,81 @@ namespace JsonDiffPatchDotNet.UnitTests
 		}
 
 		[Test]
-		public void Diff_EfficientArrayDiffWithComplexObjects_IncludeMove_ValidDiff()
+		public void Diff_EfficientArrayDiffWithComplexObjectHeadAdded_NoObjectHash_DisabledMove_ValidDiff()
 		{
-			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, ObjectHash = (jObj) => jObj["Id"].Value<string>(), DiffArrayOptions = new ArrayOptions { DetectMove = true, IncludeValueOnMove = true } });
-			//var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient });
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, DiffArrayOptions = new ArrayOptions { DetectMove = false, IncludeValueOnMove = false } });
 			var left = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
-			var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}]");
+			var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC7"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
 
 			JObject diff = jdp.Diff(left, right) as JObject;
 
 			Assert.IsNotNull(diff);
-			Assert.AreEqual(4, diff.Properties().Count());
-			Assert.AreEqual(diff["_2"], JToken.Parse("['', 0, 3]"));
-			Assert.AreEqual(diff["0"]["p"], JToken.Parse("[true, false]"));
-			Assert.AreEqual(diff["1"]["p"], JToken.Parse("[false, true]"));
+			Assert.AreEqual(5, diff.Properties().Count());
+			Assert.AreEqual(diff["0"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC7""]"));
+			Assert.AreEqual(diff["1"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8""]"));
+			Assert.AreEqual(diff["2"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9""]"));
+			Assert.AreEqual(diff["3"], JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]"));
+		}
+
+		[Test]
+		public void Diff_EfficientArrayDiffWithComplexObjectHeadAdded_NoObjectHash_EnableddMove_ValidDiff()
+		{
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, DiffArrayOptions = new ArrayOptions { DetectMove = true, IncludeValueOnMove = true } });
+			var left = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
+			var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC7"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
+
+			JObject diff = jdp.Diff(left, right) as JObject;
+
+			Assert.IsNotNull(diff);
+			Assert.AreEqual(5, diff.Properties().Count());
+			Assert.AreEqual(diff["0"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC7""]"));
+			Assert.AreEqual(diff["1"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8""]"));
+			Assert.AreEqual(diff["2"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9""]"));
+			Assert.AreEqual(diff["3"], JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]"));
+		}
+
+		[Test]
+		public void Diff_EfficientArrayDiffWithComplexObjectMiddleAdded_NoObjectHash_EnabledMove_ValidDiff()
+		{
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, DiffArrayOptions = new ArrayOptions { DetectMove = true, IncludeValueOnMove = true } });
+			var left = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}]");
+			var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""NEW ID VALUE"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}]");
+
+			JObject diff = jdp.Diff(left, right) as JObject;
+
+			Assert.IsNotNull(diff);
+			Assert.AreEqual(3, diff.Properties().Count());
+			Assert.AreEqual(diff["2"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""NEW ID VALUE""]"));
+			Assert.AreEqual(diff["3"], JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}]"));
+		}
+
+		[Test]
+		public void Diff_EfficientArrayDiffWithComplexObjectMiddleRemoved_NoObjectHash_EnabledMove_ValidDiff()
+		{
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient, DiffArrayOptions = new ArrayOptions { DetectMove = true, IncludeValueOnMove = true } });
+			var left = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
+			var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
+
+			JObject diff = jdp.Diff(left, right) as JObject;
+
+			Assert.IsNotNull(diff);
+			Assert.AreEqual(3, diff.Properties().Count());
+			Assert.AreEqual(diff["1"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10""]"));
+			Assert.IsNotNull(diff["_2"]);
+		}
+
+		[Test]
+		public void Diff_EfficientArrayDiffWithComplexObject_NoObjectHash_ValidDiff()
+		{
+			var jdp = new JsonDiffPatch(new Options { ArrayDiff = ArrayDiffMode.Efficient });
+			var left = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
+			var right = JToken.Parse(@"[{""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC8"", ""p"":false}, {""Id"" : ""NEW ID VALUE"", ""p"":true}, {""Id"" : ""F12B21EF-F57D-4958-ADDC-A3F52EC25EC10"", ""p"":true}]");
+
+			JObject diff = jdp.Diff(left, right) as JObject;
+
+			Assert.IsNotNull(diff);
+			Assert.AreEqual(2, diff.Properties().Count());
+			Assert.AreEqual(diff["1"]["Id"], JToken.Parse(@"[""F12B21EF-F57D-4958-ADDC-A3F52EC25EC9"", ""NEW ID VALUE""]"));
 		}
 
 		[Test]

--- a/Src/JsonDiffPatchDotNet/ItemMatch.cs
+++ b/Src/JsonDiffPatchDotNet/ItemMatch.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,14 +26,29 @@ namespace JsonDiffPatchDotNet
             return Match(object1, object2, ObjectHash);
         }
 
+		public virtual bool MatchArrayElement(JToken object1, int index1, JToken object2, int index2)
+		{
+			if(ObjectHash != null)
+			{
+				return Match(object1, object2, ObjectHash);
+			}
+
+			if(object1.Type != JTokenType.Object && object1.Type != JTokenType.Array)
+			{
+				return JToken.DeepEquals(object1, object2);
+			}
+
+			return index1 == index2;
+		}
+
         public virtual bool Match(JToken object1, JToken object2, Func<JToken, object> objectHash)
         {
-            if(objectHash == null || object1.Type != JTokenType.Object)
-            {
-                return JToken.DeepEquals(object1, object2);
-            }
+			if(objectHash == null || object1.Type != JTokenType.Object)
+			{
+				return JToken.DeepEquals(object1, object2);
+			}
 
-            var hash1 = objectHash.Invoke(object1);
+			var hash1 = objectHash.Invoke(object1);
             if(hash1 == null)
             {
                 return false;
@@ -43,6 +58,7 @@ namespace JsonDiffPatchDotNet
             {
                 return false;
             }
+
             return hash1.Equals(hash2);
         }
     }

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
@@ -394,7 +394,11 @@ namespace JsonDiffPatchDotNet
 
 			while (commonHead < left.Count
 				&& commonHead < right.Count
-				&& itemMatch.Match(left[commonHead], right[commonHead]))
+				&& itemMatch.MatchArrayElement(
+					left[commonHead],
+					commonHead,
+					right[commonHead],
+					commonHead))
 			{
 				var index = commonHead;
 				var child = Diff(left[index], right[index]);
@@ -407,7 +411,11 @@ namespace JsonDiffPatchDotNet
 
 			while (commonTail + commonHead < left.Count
                 && commonTail + commonHead < right.Count
-                && itemMatch.Match(left[left.Count - 1 - commonTail], right[right.Count - 1 - commonTail]))
+                && itemMatch.MatchArrayElement(
+					left[left.Count - 1 - commonTail],
+					left.Count - 1 - commonTail,
+					right[right.Count - 1 - commonTail],
+					right.Count - 1 - commonTail))
             {
                 var index1 = left.Count - 1 - commonTail;
                 var index2 = right.Count - 1 - commonTail;

--- a/Src/JsonDiffPatchDotNet/Lcs.cs
+++ b/Src/JsonDiffPatchDotNet/Lcs.cs
@@ -34,7 +34,7 @@ namespace JsonDiffPatchDotNet
             {
                 for (int j = 1; j <= right.Count; j++)
                 {
-                    if (match.Match(left[i - 1], right[j - 1]))
+                    if (match.MatchArrayElement(left[i - 1], i-1, right[j - 1], j-1))
                     {
                         arr[i, j] = arr[i - 1, j - 1] + 1;
                     }


### PR DESCRIPTION
The last release introduced a bug that incorrectly handled object changes within arrays: https://github.com/wbish/jsondiffpatch.net/issues/73. The objecthash functionality, which allows user-defined comparison for objects in an array, was initially implemented with a default to the hash of the object itself. The correct behavior, if this library is to match the behavior of the original library, is to default to index matching and not full object comparison in array diffs. This PR corrects the default behavior to do just that.

For reference, here is the explanation of how it works in the original library: https://github.com/benjamine/jsondiffpatch/blob/master/docs/arrays.md.