### PR TITLE
Fixes #75 by looking at original value before replacing

### DIFF
--- a/Src/JsonDiffPatchDotNet.UnitTests/UnpatchUnitTests.cs
+++ b/Src/JsonDiffPatchDotNet.UnitTests/UnpatchUnitTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -237,6 +237,34 @@ namespace JsonDiffPatchDotNet.UnitTests
 			var patched = jdp.Unpatch(right, patch);
 
 			Assert.IsTrue(JToken.DeepEquals(left.ToString(), patched.ToString()));
+		}
+
+		[Test]
+		public void Unpatch_ObjectIfOldValueMatches_Success()
+		{
+			var jdpUnpatchIgnoreOriginalValue = new JsonDiffPatch(new Options { UnpatchIgnoreOriginalValue = false });
+			var jdp = new JsonDiffPatch();
+			var stage1 = JToken.Parse(@"{""stage"":1}");
+			var stage2 = JToken.Parse(@"{""stage"":2}");
+			var stage3 = JToken.Parse(@"{""stage"":3}");
+
+			var diff = jdp.Diff(stage1, stage2);
+
+			// Try to unpatch with stage2 not ignoring original value
+			var unpatched_stage2 = jdpUnpatchIgnoreOriginalValue.Unpatch(stage2, diff);
+			Assert.AreEqual(stage1.ToString(), unpatched_stage2.ToString());
+
+			// Try to unpatch with stage3 not ignoring original value
+			var unpatched_stage3 = jdpUnpatchIgnoreOriginalValue.Unpatch(stage3, diff);
+			Assert.AreNotEqual(stage1.ToString(), unpatched_stage3.ToString());
+
+			// Try to unpatch with stage2 ignoring original value
+			unpatched_stage2 = jdp.Unpatch(stage2, diff);
+			Assert.AreEqual(stage1.ToString(), unpatched_stage2.ToString());
+
+			// Try to unpatch with stage3 ignoring original value
+			unpatched_stage3 = jdp.Unpatch(stage3, diff);
+			Assert.AreEqual(stage1.ToString(), unpatched_stage3.ToString());
 		}
 	}
 }

--- a/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
+++ b/Src/JsonDiffPatchDotNet/JsonDiffPatch.cs
@@ -206,7 +206,14 @@ namespace JsonDiffPatchDotNet
 
 				if (patchArray.Count == 2)	// Replace
 				{
-					return patchArray[0];
+					if (_options.UnpatchIgnoreOriginalValue || right != null && right.Type == patchArray[1].Type && right.Value<JValue>().Equals(patchArray[1].Value<JValue>()))
+					{
+						return patchArray[0];
+					}
+					else
+					{
+						return right;
+					}
 				}
 
 				if (patchArray.Count == 3)	// Delete, Move or TextDiff

--- a/Src/JsonDiffPatchDotNet/Options.cs
+++ b/Src/JsonDiffPatchDotNet/Options.cs
@@ -13,6 +13,7 @@ namespace JsonDiffPatchDotNet
 			TextDiff = TextDiffMode.Efficient;
 			MinEfficientTextDiffLength = 50;
 			DiffArrayOptions = new ArrayOptions();
+			UnpatchIgnoreOriginalValue = true;
 		}
 
 		/// <summary>
@@ -57,7 +58,9 @@ namespace JsonDiffPatchDotNet
         /// To improve the results leveraging the power of LCS(and position move detection) you need to provide a way to compare 2 objects.
         /// </summary>
         public Func<JToken, object> ObjectHash { get; set; }
-    }
+
+		public bool UnpatchIgnoreOriginalValue { get; set; }
+	}
 
 	public sealed class ArrayOptions
 	{


### PR DESCRIPTION
This tries to implement a fix for #75 that allows looking at values before unpatching.

I am unsure what a few of the edits are about. It seems the `.editorconfig` is slightly weird or not applied after being added